### PR TITLE
fix: 修复 ChatGPT 注册任务的停止/跳过控制失效问题

### DIFF
--- a/api/tasks.py
+++ b/api/tasks.py
@@ -1,72 +1,111 @@
+import asyncio
+import json
+import logging
+import threading
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Optional
+
 from fastapi import APIRouter, BackgroundTasks, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 from sqlmodel import Session, select
-from typing import Optional
-from core.db import TaskLog, engine
-import time, json, asyncio, threading, logging
+
+from core.db import ScheduledTaskModel, TaskLog, engine
+from core.task_runtime import (
+    AttemptOutcome,
+    AttemptResult,
+    RegisterTaskStore,
+    SkipCurrentAttemptRequested,
+    StopTaskRequested,
+)
 
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 logger = logging.getLogger(__name__)
 
-_tasks: dict = {}
-_tasks_lock = threading.Lock()
-
 MAX_FINISHED_TASKS = 200
 CLEANUP_THRESHOLD = 250
 
-
-def _cleanup_old_tasks():
-    """Remove oldest finished tasks when the dict grows too large."""
-    with _tasks_lock:
-        finished = [
-            (tid, t) for tid, t in _tasks.items()
-            if t.get("status") in ("done", "failed")
-        ]
-        if len(finished) <= MAX_FINISHED_TASKS:
-            return
-        finished.sort(key=lambda x: x[0])
-        to_remove = finished[: len(finished) - MAX_FINISHED_TASKS]
-        for tid, _ in to_remove:
-            del _tasks[tid]
+_task_store = RegisterTaskStore(
+    max_finished_tasks=MAX_FINISHED_TASKS,
+    cleanup_threshold=CLEANUP_THRESHOLD,
+)
 
 
 class RegisterTaskRequest(BaseModel):
     platform: str
     email: Optional[str] = None
     password: Optional[str] = None
-    count: int = Field(default=1, ge=1, le=1000)  # 最大支持 1000 个
-    concurrency: int = Field(default=1, ge=1, le=10)  # 最大并发 10
+    count: int = Field(default=1, ge=1, le=1000)
+    concurrency: int = Field(default=1, ge=1, le=10)
     register_delay_seconds: float = Field(default=0, ge=0)
-    random_delay_min: Optional[float] = Field(default=None, ge=0)  # 随机延迟最小值 (秒)
-    random_delay_max: Optional[float] = Field(default=None, ge=0)  # 随机延迟最大值 (秒)
+    random_delay_min: Optional[float] = Field(default=None, ge=0)
+    random_delay_max: Optional[float] = Field(default=None, ge=0)
     proxy: Optional[str] = None
     executor_type: str = "protocol"
     captcha_solver: str = "yescaptcha"
     extra: dict = Field(default_factory=dict)
-    # 定时任务配置
-    task_id: Optional[str] = None  # 定时任务 ID（更新时使用）
-    interval_type: Optional[str] = None  # minutes | hours
-    interval_value: Optional[int] = None  # 间隔值
+    task_id: Optional[str] = None
+    interval_type: Optional[str] = None
+    interval_value: Optional[int] = None
 
 
 class TaskLogBatchDeleteRequest(BaseModel):
     ids: list[int]
 
 
+def _ensure_task_exists(task_id: str) -> None:
+    if not _task_store.exists(task_id):
+        raise HTTPException(404, "任务不存在")
+
+
+def _prepare_register_request(req: RegisterTaskRequest) -> RegisterTaskRequest:
+    mail_provider = req.extra.get("mail_provider")
+    if mail_provider == "luckmail":
+        if req.platform in ("tavily", "openblocklabs"):
+            raise HTTPException(400, f"LuckMail 渠道暂时不支持 {req.platform} 项目注册")
+
+        mapping = {
+            "trae": "trae",
+            "cursor": "cursor",
+            "grok": "grok",
+            "kiro": "kiro",
+            "chatgpt": "openai",
+        }
+        req.extra["luckmail_project_code"] = mapping.get(req.platform, req.platform)
+    return req
+
+
+def _create_task_record(
+    task_id: str,
+    req: RegisterTaskRequest,
+    source: str,
+    meta: dict[str, Any] | None,
+):
+    return _task_store.create(
+        task_id,
+        platform=req.platform,
+        total=req.count,
+        source=source,
+        meta=meta,
+    )
+
+
 def _log(task_id: str, msg: str):
-    """向任务追加一条日志"""
     ts = time.strftime("%H:%M:%S")
     entry = f"[{ts}] {msg}"
-    with _tasks_lock:
-        if task_id in _tasks:
-            _tasks[task_id].setdefault("logs", []).append(entry)
+    _task_store.append_log(task_id, entry)
     print(entry)
 
 
-def _save_task_log(platform: str, email: str, status: str,
-                   error: str = "", detail: dict = None):
-    """Write a TaskLog record to the database."""
+def _save_task_log(
+    platform: str,
+    email: str,
+    status: str,
+    error: str = "",
+    detail: dict | None = None,
+):
     with Session(engine) as s:
         log = TaskLog(
             platform=platform,
@@ -80,7 +119,6 @@ def _save_task_log(platform: str, email: str, status: str,
 
 
 def _auto_upload_integrations(task_id: str, account):
-    """注册成功后自动导入外部系统。"""
     try:
         from services.external_sync import sync_account
 
@@ -89,148 +127,251 @@ def _auto_upload_integrations(task_id: str, account):
             ok = bool(result.get("ok"))
             msg = result.get("msg", "")
             _log(task_id, f"  [{name}] {'[OK] ' + msg if ok else '[FAIL] ' + msg}")
-    except Exception as e:
-        _log(task_id, f"  [Auto Upload] 自动导入异常: {e}")
+    except Exception as exc:
+        _log(task_id, f"  [Auto Upload] 自动导入异常: {exc}")
+
+
+def _sleep_with_task_control(
+    seconds: float,
+    *,
+    task_control,
+    attempt_id: int,
+):
+    remaining = max(float(seconds or 0), 0.0)
+    while remaining > 0:
+        task_control.checkpoint(attempt_id=attempt_id)
+        chunk = min(0.25, remaining)
+        time.sleep(chunk)
+        remaining -= chunk
+
+
+def _build_register_meta(req: RegisterTaskRequest, *, scope: str) -> dict[str, Any]:
+    return {
+        "scope": scope,
+        "count": req.count,
+        "concurrency": req.concurrency,
+    }
 
 
 def _run_register(task_id: str, req: RegisterTaskRequest):
-    from core.registry import get
-    from core.base_platform import RegisterConfig
-    from core.db import save_account
-    from core.base_mailbox import create_mailbox
+    from concurrent.futures import ThreadPoolExecutor, as_completed
 
-    with _tasks_lock:
-        _tasks[task_id]["status"] = "running"
+    from core.base_mailbox import create_mailbox
+    from core.base_platform import RegisterConfig
+    from core.config_store import config_store
+    from core.db import save_account
+    from core.proxy_pool import proxy_pool
+    from core.registry import get
+
+    _ensure_task_exists(task_id)
+    task_control = _task_store.control_for(task_id)
+    _task_store.mark_running(task_id)
+
     success = 0
-    errors = []
+    skipped = 0
+    errors: list[str] = []
     start_gate_lock = threading.Lock()
     next_start_time = time.time()
 
     try:
-        PlatformCls = get(req.platform)
+        platform_cls = get(req.platform)
 
         def _build_mailbox(proxy: Optional[str]):
-            from core.config_store import config_store
             merged_extra = config_store.get_all().copy()
-            merged_extra.update({k: v for k, v in req.extra.items() if v is not None and v != ""})
+            merged_extra.update(
+                {k: v for k, v in req.extra.items() if v is not None and v != ""}
+            )
             return create_mailbox(
                 provider=merged_extra.get("mail_provider", "laoudo"),
                 extra=merged_extra,
                 proxy=proxy,
             )
 
-        def _do_one(i: int):
+        def _do_one(i: int) -> AttemptResult:
             nonlocal next_start_time
-            try:
-                from core.proxy_pool import proxy_pool
 
-                _proxy = req.proxy
+            attempt_id = task_control.start_attempt()
+            _proxy = req.proxy
+            try:
+                task_control.checkpoint(attempt_id=attempt_id)
                 if not _proxy:
                     _proxy = proxy_pool.get_next()
-                # 延迟控制
-                if req.register_delay_seconds > 0 or (req.random_delay_min is not None and req.random_delay_max is not None):
+
+                if req.register_delay_seconds > 0 or (
+                    req.random_delay_min is not None
+                    and req.random_delay_max is not None
+                ):
                     with start_gate_lock:
                         now = time.time()
                         wait_seconds = max(0.0, next_start_time - now)
-                        
-                        # 固定延迟
+
                         if req.register_delay_seconds > 0 and wait_seconds > 0:
-                            _log(task_id, f"第 {i+1} 个账号启动前延迟 {wait_seconds:g} 秒")
-                            time.sleep(wait_seconds)
+                            _log(task_id, f"第 {i + 1} 个账号启动前延迟 {wait_seconds:g} 秒")
+                            _sleep_with_task_control(
+                                wait_seconds,
+                                task_control=task_control,
+                                attempt_id=attempt_id,
+                            )
                         next_start_time = time.time() + req.register_delay_seconds
-                        
-                        # 随机延迟
-                        if req.random_delay_min is not None and req.random_delay_max is not None:
+
+                        if (
+                            req.random_delay_min is not None
+                            and req.random_delay_max is not None
+                        ):
                             import random
-                            random_delay = random.uniform(req.random_delay_min, req.random_delay_max)
+
+                            random_delay = random.uniform(
+                                req.random_delay_min,
+                                req.random_delay_max,
+                            )
                             if random_delay > 0:
-                                _log(task_id, f"第 {i+1} 个账号随机延迟 {random_delay:.1f} 秒 ({req.random_delay_min}-{req.random_delay_max}秒)")
-                                time.sleep(random_delay)
+                                _log(
+                                    task_id,
+                                    f"第 {i + 1} 个账号随机延迟 {random_delay:.1f} 秒 "
+                                    f"({req.random_delay_min}-{req.random_delay_max}秒)",
+                                )
+                                _sleep_with_task_control(
+                                    random_delay,
+                                    task_control=task_control,
+                                    attempt_id=attempt_id,
+                                )
                             next_start_time = time.time() + random_delay
-                from core.config_store import config_store
+
                 merged_extra = config_store.get_all().copy()
-                merged_extra.update({k: v for k, v in req.extra.items() if v is not None and v != ""})
-                
-                _config = RegisterConfig(
+                merged_extra.update(
+                    {k: v for k, v in req.extra.items() if v is not None and v != ""}
+                )
+                config = RegisterConfig(
                     executor_type=req.executor_type,
                     captcha_solver=req.captcha_solver,
                     proxy=_proxy,
                     extra=merged_extra,
                 )
-                _mailbox = _build_mailbox(_proxy)
-                _platform = PlatformCls(config=_config, mailbox=_mailbox)
-                _platform._log_fn = lambda msg: _log(task_id, msg)
-                if getattr(_platform, "mailbox", None) is not None:
-                    _platform.mailbox._log_fn = _platform._log_fn
-                with _tasks_lock:
-                    _tasks[task_id]["progress"] = f"{i+1}/{req.count}"
-                _log(task_id, f"开始注册第 {i+1}/{req.count} 个账号")
-                if _proxy: _log(task_id, f"使用代理: {_proxy}")
-                account = _platform.register(
+                mailbox = _build_mailbox(_proxy)
+                platform = platform_cls(config=config, mailbox=mailbox)
+                platform._log_fn = lambda msg: _log(task_id, msg)
+                platform.bind_task_control(task_control)
+                if getattr(platform, "mailbox", None) is not None:
+                    platform.mailbox._log_fn = platform._log_fn
+                    platform.mailbox._task_attempt_token = attempt_id
+
+                _task_store.set_progress(task_id, f"{i + 1}/{req.count}")
+                _log(task_id, f"开始注册第 {i + 1}/{req.count} 个账号")
+                if _proxy:
+                    _log(task_id, f"使用代理: {_proxy}")
+
+                task_control.checkpoint(attempt_id=attempt_id)
+                account = platform.register(
                     email=req.email or None,
                     password=req.password,
                 )
+                task_control.checkpoint(attempt_id=attempt_id)
+
                 if isinstance(account.extra, dict):
                     mail_provider = merged_extra.get("mail_provider", "")
                     if mail_provider:
                         account.extra.setdefault("mail_provider", mail_provider)
                     if mail_provider == "luckmail" and req.platform == "chatgpt":
-                        mailbox_token = getattr(_mailbox, "_token", "") or ""
+                        mailbox_token = getattr(mailbox, "_token", "") or ""
                         if mailbox_token:
                             account.extra.setdefault("mailbox_token", mailbox_token)
-                        if merged_extra.get("luckmail_project_code"):
-                            account.extra.setdefault("luckmail_project_code", merged_extra.get("luckmail_project_code"))
-                        if merged_extra.get("luckmail_email_type"):
-                            account.extra.setdefault("luckmail_email_type", merged_extra.get("luckmail_email_type"))
-                        if merged_extra.get("luckmail_domain"):
-                            account.extra.setdefault("luckmail_domain", merged_extra.get("luckmail_domain"))
-                        if merged_extra.get("luckmail_base_url"):
-                            account.extra.setdefault("luckmail_base_url", merged_extra.get("luckmail_base_url"))
+                        for key in (
+                            "luckmail_project_code",
+                            "luckmail_email_type",
+                            "luckmail_domain",
+                            "luckmail_base_url",
+                        ):
+                            value = merged_extra.get(key)
+                            if value:
+                                account.extra.setdefault(key, value)
+
                 saved_account = save_account(account)
-                if _proxy: proxy_pool.report_success(_proxy)
+                if _proxy:
+                    proxy_pool.report_success(_proxy)
                 _log(task_id, f"[OK] 注册成功: {account.email}")
                 _save_task_log(req.platform, account.email, "success")
                 _auto_upload_integrations(task_id, saved_account or account)
+
                 cashier_url = (account.extra or {}).get("cashier_url", "")
                 if cashier_url:
                     _log(task_id, f"  [升级链接] {cashier_url}")
-                    with _tasks_lock:
-                        _tasks[task_id].setdefault("cashier_urls", []).append(cashier_url)
-                return True
-            except Exception as e:
-                if _proxy: proxy_pool.report_fail(_proxy)
-                _log(task_id, f"[FAIL] 注册失败: {e}")
-                _save_task_log(req.platform, req.email or "", "failed", error=str(e))
-                return str(e)
+                    _task_store.add_cashier_url(task_id, cashier_url)
+                return AttemptResult.success()
+            except SkipCurrentAttemptRequested as exc:
+                _log(task_id, str(exc))
+                return AttemptResult.skipped(str(exc))
+            except StopTaskRequested as exc:
+                _log(task_id, str(exc))
+                return AttemptResult.stopped(str(exc))
+            except Exception as exc:
+                if _proxy:
+                    proxy_pool.report_fail(_proxy)
+                _log(task_id, f"[FAIL] 注册失败: {exc}")
+                _save_task_log(req.platform, req.email or "", "failed", error=str(exc))
+                return AttemptResult.failed(str(exc))
+            finally:
+                task_control.finish_attempt(attempt_id)
 
-        from concurrent.futures import ThreadPoolExecutor, as_completed
         max_workers = min(req.concurrency, req.count, 5)
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
             futures = [pool.submit(_do_one, i) for i in range(req.count)]
-            for f in as_completed(futures):
+            for future in as_completed(futures):
                 try:
-                    result = f.result()
-                except Exception as e:
-                    _log(task_id, f"[ERROR] 任务线程异常: {e}")
-                    errors.append(str(e))
+                    result = future.result()
+                except Exception as exc:
+                    _log(task_id, f"[ERROR] 任务线程异常: {exc}")
+                    errors.append(str(exc))
                     continue
-                if result is True:
+
+                if result.outcome == AttemptOutcome.SUCCESS:
                     success += 1
-                else:
-                    errors.append(result)
-    except Exception as e:
-        _log(task_id, f"致命错误: {e}")
-        with _tasks_lock:
-            _tasks[task_id]["status"] = "failed"
-            _tasks[task_id]["error"] = str(e)
+                elif result.outcome == AttemptOutcome.SKIPPED:
+                    skipped += 1
+                elif result.outcome == AttemptOutcome.FAILED:
+                    errors.append(result.message)
+                elif result.outcome == AttemptOutcome.STOPPED:
+                    pass
+    except StopTaskRequested as exc:
+        _log(task_id, str(exc))
+    except Exception as exc:
+        _log(task_id, f"致命错误: {exc}")
+        _task_store.finish(
+            task_id,
+            status="failed",
+            success=success,
+            skipped=skipped,
+            errors=errors,
+            error=str(exc),
+        )
+        _task_store.cleanup()
         return
 
-    with _tasks_lock:
-        _tasks[task_id]["status"] = "done"
-        _tasks[task_id]["success"] = success
-        _tasks[task_id]["errors"] = errors
-    _log(task_id, f"完成: 成功 {success} 个, 失败 {len(errors)} 个")
-    _cleanup_old_tasks()
+    final_status = "stopped" if task_control.is_stop_requested() else "done"
+    _task_store.finish(
+        task_id,
+        status=final_status,
+        success=success,
+        skipped=skipped,
+        errors=errors,
+    )
+    summary = f"完成: 成功 {success} 个, 跳过 {skipped} 个, 失败 {len(errors)} 个"
+    if final_status == "stopped":
+        summary = f"任务已停止: 成功 {success} 个, 跳过 {skipped} 个, 失败 {len(errors)} 个"
+    _log(task_id, summary)
+    _task_store.cleanup()
+
+
+def _run_scheduled_task_and_update_status(task_id: str, req: RegisterTaskRequest):
+    from core.scheduler import update_task_run_status
+
+    try:
+        _run_register(task_id, req)
+        snapshot = _task_store.snapshot(task_id)
+        success = snapshot.get("status") == "done" and not snapshot.get("errors")
+        update_task_run_status(task_id.split("_", 2)[1] if task_id.startswith("scheduled_") else task_id, success, snapshot.get("error"))
+    except Exception as exc:
+        update_task_run_status(task_id, False, str(exc))
+        raise
 
 
 @router.post("/register")
@@ -238,38 +379,44 @@ def create_register_task(
     req: RegisterTaskRequest,
     background_tasks: BackgroundTasks,
 ):
-    mail_provider = req.extra.get("mail_provider")
-    if mail_provider == "luckmail":
-        platform = req.platform
-        if platform in ("tavily", "openblocklabs"):
-            raise HTTPException(400, f"LuckMail 渠道暂时不支持 {platform} 项目注册")
-        
-        mapping = {
-            "trae": "trae",
-            "cursor": "cursor",
-            "grok": "grok",
-            "kiro": "kiro",
-            "chatgpt": "openai"
-        }
-        req.extra["luckmail_project_code"] = mapping.get(platform, platform)
-
-    task_id = f"task_{int(time.time()*1000)}"
-    with _tasks_lock:
-        _tasks[task_id] = {"id": task_id, "status": "pending",
-                           "progress": f"0/{req.count}", "logs": []}
+    req = _prepare_register_request(req)
+    task_id = f"task_{int(time.time() * 1000)}"
+    _create_task_record(task_id, req, "manual", _build_register_meta(req, scope="manual"))
     background_tasks.add_task(_run_register, task_id, req)
     return {"task_id": task_id}
+
+
+@router.post("/{task_id}/skip-current")
+def skip_current_task_attempt(task_id: str):
+    _ensure_task_exists(task_id)
+    control = _task_store.request_skip_current(task_id)
+    return {
+        "task_id": task_id,
+        "control": control,
+        "message": "已发送跳过当前账号请求",
+    }
+
+
+@router.post("/{task_id}/stop")
+def stop_task(task_id: str):
+    _ensure_task_exists(task_id)
+    control = _task_store.request_stop(task_id)
+    return {
+        "task_id": task_id,
+        "control": control,
+        "message": "已发送停止任务请求",
+    }
 
 
 @router.get("/logs")
 def get_logs(platform: str = None, page: int = 1, page_size: int = 50):
     with Session(engine) as s:
-        q = select(TaskLog)
+        query = select(TaskLog)
         if platform:
-            q = q.where(TaskLog.platform == platform)
-        q = q.order_by(TaskLog.id.desc())
-        total = len(s.exec(q).all())
-        items = s.exec(q.offset((page - 1) * page_size).limit(page_size)).all()
+            query = query.where(TaskLog.platform == platform)
+        query = query.order_by(TaskLog.id.desc())
+        total = len(s.exec(query).all())
+        items = s.exec(query.offset((page - 1) * page_size).limit(page_size)).all()
     return {"total": total, "items": items}
 
 
@@ -294,35 +441,29 @@ def batch_delete_logs(body: TaskLogBatchDeleteRequest):
             deleted_count = len(found_ids)
             not_found_ids = [log_id for log_id in unique_ids if log_id not in found_ids]
             logger.info("批量删除任务历史成功: %s 条", deleted_count)
-
             return {
                 "deleted": deleted_count,
                 "not_found": not_found_ids,
                 "total_requested": len(unique_ids),
             }
-        except Exception as e:
+        except Exception as exc:
             s.rollback()
             logger.exception("批量删除任务历史失败")
-            raise HTTPException(500, f"批量删除任务历史失败: {str(e)}")
+            raise HTTPException(500, f"批量删除任务历史失败: {exc}")
 
 
 @router.get("/{task_id}/logs/stream")
 async def stream_logs(task_id: str, since: int = 0):
-    """SSE 实时日志流"""
-    with _tasks_lock:
-        if task_id not in _tasks:
-            raise HTTPException(404, "任务不存在")
+    _ensure_task_exists(task_id)
 
     async def event_generator():
         sent = since
         while True:
-            with _tasks_lock:
-                logs = list(_tasks.get(task_id, {}).get("logs", []))
-                status = _tasks.get(task_id, {}).get("status", "")
+            logs, status = _task_store.log_state(task_id)
             while sent < len(logs):
                 yield f"data: {json.dumps({'line': logs[sent]})}\n\n"
                 sent += 1
-            if status in ("done", "failed"):
+            if status in ("done", "failed", "stopped"):
                 yield f"data: {json.dumps({'done': True, 'status': status})}\n\n"
                 break
             await asyncio.sleep(0.5)
@@ -337,76 +478,40 @@ async def stream_logs(task_id: str, since: int = 0):
     )
 
 
-
-# 定时任务管理 API
 @router.post("/schedule/{task_id}/run")
 def run_scheduled_task_now(task_id: str, background_tasks: BackgroundTasks):
-    """立即执行定时任务"""
     from core.scheduler import get_scheduled_register_tasks, update_task_run_status
-    from api.tasks import _run_register, _log
-    import logging
-    
-    logger = logging.getLogger(__name__)
-    
+
     tasks = get_scheduled_register_tasks()
     if task_id not in tasks:
         raise HTTPException(404, "任务不存在")
-    
+
     task_config = tasks[task_id]
     run_task_id = f"manual_{task_id}_{int(time.time())}"
-    
-    # 创建 RegisterTaskRequest
     req = RegisterTaskRequest(**task_config)
-    logger.info(f"准备手动运行任务 {run_task_id}, 配置：{task_config}")
-    
+    _create_task_record(run_task_id, req, "schedule", {"scheduled_task_id": task_id, "scope": "manual-run"})
+    _log(run_task_id, f"开始手动运行定时任务 {task_id}")
+
     def run_with_status():
         try:
-            # 先初始化 _tasks 记录
-            with _tasks_lock:
-                _tasks[run_task_id] = {"id": run_task_id, "status": "pending", "progress": "0/1", "logs": []}
-            # 先记录开始
-            _log(run_task_id, f"开始手动运行定时任务 {task_id}")
             _run_register(run_task_id, req)
-            # 运行完成后更新状态（延迟一点等待 cleanup 完成）
-            import time
-            time.sleep(2)
-            update_task_run_status(task_id, True, None)
-            logger.info(f"任务 {run_task_id} 运行完成")
-        except Exception as e:
-            import traceback
-            error_msg = f"{str(e)}\n{traceback.format_exc()}"
-            update_task_run_status(task_id, False, error_msg)
-            logger.error(f"任务 {run_task_id} 运行失败：{error_msg}")
-    
+            snapshot = _task_store.snapshot(run_task_id)
+            success = snapshot.get("status") == "done" and not snapshot.get("errors")
+            update_task_run_status(task_id, success, snapshot.get("error"))
+            logger.info("任务 %s 运行完成", run_task_id)
+        except Exception as exc:
+            update_task_run_status(task_id, False, str(exc))
+            logger.exception("任务 %s 运行失败", run_task_id)
+
     background_tasks.add_task(run_with_status)
-    
     return {"task_id": run_task_id, "status": "running"}
 
-@router.post("/schedule/{task_id}/toggle")
-def toggle_scheduled_task(task_id: str):
-    """暂停或恢复定时任务"""
-    from core.scheduler import get_scheduled_register_tasks, add_scheduled_register_task
-    
-    tasks = get_scheduled_register_tasks()
-    if task_id not in tasks:
-        raise HTTPException(404, "任务不存在")
-    
-    task_config = tasks[task_id]
-    task_config['paused'] = not task_config.get('paused', False)
-    add_scheduled_register_task(task_id, task_config)
-    
-    return {"task_id": task_id, "paused": task_config['paused']}
 
 @router.post("/schedule")
 def create_scheduled_task(body: RegisterTaskRequest):
-    """创建定时注册任务"""
-    import uuid
-    from core.db import ScheduledTaskModel, Session, engine
-    from sqlmodel import select
-    
+    from core.scheduler import add_scheduled_register_task, update_task_run_status
+
     task_id = f"sched_{uuid.uuid4().hex[:8]}"
-    
-    # 保存到数据库
     db_task = ScheduledTaskModel(
         task_id=task_id,
         platform=body.platform,
@@ -422,48 +527,37 @@ def create_scheduled_task(body: RegisterTaskRequest):
         s.add(db_task)
         s.commit()
         s.refresh(db_task)
-    
-    # 添加到内存
-    from core.scheduler import add_scheduled_register_task
+
     config = body.dict()
-    config['task_id'] = task_id
+    config["task_id"] = task_id
     add_scheduled_register_task(task_id, config)
-    
-    # 创建后立即在线程中执行一次
+
     def run_now():
         run_task_id = f"scheduled_{task_id}_{int(time.time())}"
-        success = False
-        error_msg = None
+        req = RegisterTaskRequest(**config)
+        _create_task_record(run_task_id, req, "schedule", {"scheduled_task_id": task_id, "scope": "auto-run"})
         try:
-            # 先初始化 _tasks 记录
-            with _tasks_lock:
-                _tasks[run_task_id] = {"id": run_task_id, "status": "pending", "progress": "0/1", "logs": []}
-            req = RegisterTaskRequest(**config)
             _run_register(run_task_id, req)
-            success = True
+            snapshot = _task_store.snapshot(run_task_id)
+            success = snapshot.get("status") == "done" and not snapshot.get("errors")
+            update_task_run_status(task_id, success, snapshot.get("error"))
             print(f"[Scheduler] 任务 {task_id} 已执行", flush=True)
-        except Exception as e:
-            error_msg = str(e)
-            print(f"[Scheduler] 任务 {task_id} 执行失败：{e}", flush=True)
-        finally:
-            # 更新任务运行状态
-            from core.scheduler import update_task_run_status
-            update_task_run_status(task_id, success, error_msg)
-    
+        except Exception as exc:
+            update_task_run_status(task_id, False, str(exc))
+            print(f"[Scheduler] 任务 {task_id} 执行失败：{exc}", flush=True)
+
     threading.Thread(target=run_now, daemon=True).start()
     print(f"[Scheduler] 任务 {task_id} 已创建并启动", flush=True)
-    
     return {"task_id": task_id, "status": "scheduled", "config": config}
 
 
 @router.get("/schedule")
 def list_scheduled_tasks():
-    """获取所有定时任务"""
-    from core.scheduler import get_scheduled_register_tasks, get_all_task_run_status
+    from core.scheduler import get_all_task_run_status, get_scheduled_register_tasks
+
     tasks = get_scheduled_register_tasks()
     run_status = get_all_task_run_status()
-    
-    # 合并运行状态
+
     result = []
     for task in tasks.values():
         task_data = dict(task)
@@ -475,84 +569,45 @@ def list_scheduled_tasks():
             task_data.setdefault("last_run_success", None)
             task_data.setdefault("last_error", None)
         result.append(task_data)
-    
     return {"tasks": result}
 
 
-@router.delete("/schedule/{task_id}")
-def delete_scheduled_task(task_id: str):
-    """删除定时任务"""
-    from core.scheduler import remove_scheduled_register_task
-    remove_scheduled_register_task(task_id)
-    return {"ok": True}
-
-@router.get("/{task_id}")
-def get_task(task_id: str):
-    with _tasks_lock:
-        if task_id not in _tasks:
-            raise HTTPException(404, "任务不存在")
-        return _tasks[task_id]
-
-
-@router.get("")
-def list_tasks():
-    with _tasks_lock:
-        return list(_tasks.values())
-
-
-
-# 定时任务管理 API - 更新任务
 @router.put("/schedule")
 def update_scheduled_task(body: RegisterTaskRequest):
-    """更新定时任务配置"""
-    from core.scheduler import get_scheduled_register_tasks, add_scheduled_register_task, remove_scheduled_register_task
-    
-    # 从根级别或 extra 中获取 task_id
-    task_id = getattr(body, 'task_id', None) or (body.extra and body.extra.get('task_id'))
+    from core.scheduler import add_scheduled_register_task, get_scheduled_register_tasks
+
+    task_id = getattr(body, "task_id", None) or (body.extra and body.extra.get("task_id"))
     if not task_id:
         raise HTTPException(400, "缺少任务 ID")
-    
+
     tasks = get_scheduled_register_tasks()
     if task_id not in tasks:
         raise HTTPException(404, "任务不存在")
-    
+
     config = body.dict()
-    config['task_id'] = task_id
+    config["task_id"] = task_id
     add_scheduled_register_task(task_id, config)
-    
     return {"task_id": task_id, "status": "updated", "config": config}
-
-
-# 手动运行定时任务
-
-
-
-# 暂停/恢复定时任务
-
 
 
 @router.delete("/schedule/{task_id}")
 def delete_scheduled_task(task_id: str):
-    """删除定时任务"""
-    from core.db import ScheduledTaskModel, Session, engine
     from core.scheduler import remove_scheduled_register_task
-    
+
     with Session(engine) as s:
         task = s.get(ScheduledTaskModel, task_id)
         if task:
             s.delete(task)
             s.commit()
-    
+
     remove_scheduled_register_task(task_id)
     return {"ok": True}
 
 
 @router.post("/schedule/{task_id}/toggle")
 def toggle_scheduled_task(task_id: str):
-    """暂停或恢复定时任务"""
-    from core.db import ScheduledTaskModel, Session, engine
     from core.scheduler import add_scheduled_register_task, get_scheduled_register_tasks
-    
+
     with Session(engine) as s:
         task = s.get(ScheduledTaskModel, task_id)
         if not task:
@@ -561,11 +616,23 @@ def toggle_scheduled_task(task_id: str):
         task.updated_at = datetime.now(timezone.utc)
         s.add(task)
         s.commit()
-        
-        # 更新内存中的任务
-        tasks = get_scheduled_register_tasks()
-        if task_id in tasks:
-            tasks[task_id]['paused'] = task.paused
-            add_scheduled_register_task(task_id, tasks[task_id])
-    
+
+    tasks = get_scheduled_register_tasks()
+    if task_id in tasks:
+        task_config = dict(tasks[task_id])
+        task_config["paused"] = task.paused
+        add_scheduled_register_task(task_id, task_config)
+
     return {"task_id": task_id, "paused": task.paused}
+
+
+@router.get("/{task_id}")
+def get_task(task_id: str):
+    _ensure_task_exists(task_id)
+    return _task_store.snapshot(task_id)
+
+
+@router.get("")
+def list_tasks():
+    return _task_store.list_snapshots()
+

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -251,6 +251,7 @@ def _run_register(task_id: str, req: RegisterTaskRequest):
                 platform = platform_cls(config=config, mailbox=mailbox)
                 platform._log_fn = lambda msg: _log(task_id, msg)
                 platform.bind_task_control(task_control)
+                platform._task_attempt_token = attempt_id
                 if getattr(platform, "mailbox", None) is not None:
                     platform.mailbox._log_fn = platform._log_fn
                     platform.mailbox._task_attempt_token = attempt_id
@@ -635,4 +636,3 @@ def get_task(task_id: str):
 @router.get("")
 def list_tasks():
     return _task_store.list_snapshots()
-

--- a/core/base_platform.py
+++ b/core/base_platform.py
@@ -98,7 +98,9 @@ class BasePlatform(ABC):
         task_control = getattr(self, "_task_control", None)
         if task_control is None:
             return
-        task_control.checkpoint()
+        task_control.checkpoint(
+            attempt_id=getattr(self, "_task_attempt_token", None),
+        )
 
     def build_interrupt_checker(self):
         """导出给非平台类复用的 checkpoint 回调。"""
@@ -107,7 +109,9 @@ class BasePlatform(ABC):
             return None
 
         def _interrupt_checker():
-            task_control.checkpoint()
+            task_control.checkpoint(
+                attempt_id=getattr(self, "_task_attempt_token", None),
+            )
 
         return _interrupt_checker
 

--- a/core/base_platform.py
+++ b/core/base_platform.py
@@ -93,6 +93,24 @@ class BasePlatform(ABC):
         if mailbox is not None:
             mailbox._task_control = task_control
 
+    def checkpoint_task_control(self) -> None:
+        """在平台内部显式消费 stop/skip 信号。"""
+        task_control = getattr(self, "_task_control", None)
+        if task_control is None:
+            return
+        task_control.checkpoint()
+
+    def build_interrupt_checker(self):
+        """导出给非平台类复用的 checkpoint 回调。"""
+        task_control = getattr(self, "_task_control", None)
+        if task_control is None:
+            return None
+
+        def _interrupt_checker():
+            task_control.checkpoint()
+
+        return _interrupt_checker
+
     def get_mailbox_otp_timeout(self, default: int = 120) -> int:
         """统一解析邮箱 OTP 等待秒数，避免平台内散落魔法值。"""
         extra = getattr(self.config, "extra", {}) or {}

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -86,7 +86,7 @@ class Scheduler:
         """检查并执行到期的定时任务"""
         # 延迟导入，避免循环导入
         global _scheduled_register_tasks, _task_run_status, _scheduled_tasks_lock, _task_status_lock
-        from api.tasks import _run_register, RegisterTaskRequest
+        from api.tasks import _create_task_record, _run_register, _task_store, RegisterTaskRequest
         
         with _scheduled_tasks_lock:
             tasks = dict(_scheduled_register_tasks)
@@ -131,20 +131,28 @@ class Scheduler:
                 print(f"[Scheduler] 执行定时任务 {task_id}")
                 run_task_id = f"scheduled_{task_id}_{int(time.time())}"
                 def run_task():
+                    success = False
+                    error = None
                     try:
-                        # 初始化 _tasks 记录
-                        from api.tasks import _tasks, _tasks_lock
-                        with _tasks_lock:
-                            _tasks[run_task_id] = {"id": run_task_id, "status": "pending", "progress": "0/1", "logs": []}
                         req = RegisterTaskRequest(**task_config)
+                        _create_task_record(
+                            run_task_id,
+                            req,
+                            "schedule",
+                            {"scheduled_task_id": task_id, "scope": "auto-run"},
+                        )
                         _run_register(run_task_id, req)
+                        snapshot = _task_store.snapshot(run_task_id)
+                        success = snapshot.get("status") == "done" and not snapshot.get("errors")
+                        error = snapshot.get("error")
                         print(f"[Scheduler] 任务 {task_id} 执行完成")
                     except Exception as e:
+                        error = str(e)
                         print(f"[Scheduler] 任务 {task_id} 执行失败：{e}")
                     finally:
                         # 更新运行状态
                         from core.scheduler import update_task_run_status
-                        update_task_run_status(task_id, True, None)
+                        update_task_run_status(task_id, success, error)
                 threading.Thread(target=run_task, daemon=True).start()
 
 

--- a/platforms/chatgpt/access_token_only_registration_engine.py
+++ b/platforms/chatgpt/access_token_only_registration_engine.py
@@ -47,6 +47,7 @@ class AccessTokenOnlyRegistrationEngine:
         task_uuid: Optional[str] = None,
         max_retries: int = 3,
         extra_config: Optional[dict] = None,
+        interrupt_checker: Optional[Callable[[], None]] = None,
     ):
         self.email_service = email_service
         self.proxy_url = proxy_url
@@ -55,12 +56,28 @@ class AccessTokenOnlyRegistrationEngine:
         self.task_uuid = task_uuid
         self.max_retries = max(1, int(max_retries or 1))
         self.extra_config = dict(extra_config or {})
+        self.interrupt_checker = interrupt_checker
         
         self.email = None
         self.password = None
         self.logs = []
+
+    def _checkpoint(self) -> None:
+        checker = self.interrupt_checker
+        if callable(checker):
+            checker()
+
+    def _sleep_with_checkpoint(self, seconds: float) -> None:
+        remaining = max(float(seconds or 0), 0.0)
+        sleep_fn = time.sleep
+        while remaining > 0:
+            self._checkpoint()
+            chunk = min(0.25, remaining)
+            sleep_fn(chunk)
+            remaining -= chunk
         
     def _log(self, message: str, level: str = "info"):
+        self._checkpoint()
         timestamp = datetime.now().strftime("%H:%M:%S")
         log_message = f"[{timestamp}] {message}"
         self.logs.append(log_message)
@@ -100,6 +117,7 @@ class AccessTokenOnlyRegistrationEngine:
             last_error = ""
             for attempt in range(self.max_retries):
                 try:
+                    self._checkpoint()
                     if attempt == 0:
                         self._log("=" * 60)
                         self._log("开始注册流程 V2 (Session 复用直取 AccessToken)")
@@ -107,9 +125,10 @@ class AccessTokenOnlyRegistrationEngine:
                         self._log("=" * 60)
                     else:
                         self._log(f"整流程重试 {attempt + 1}/{self.max_retries} ...")
-                        time.sleep(1)
+                        self._sleep_with_checkpoint(1)
 
                     # 1. 创建邮箱
+                    self._checkpoint()
                     email_data = self.email_service.create_email()
                     email_addr = self.email or (email_data.get('email') if email_data else None)
                     if not email_addr:
@@ -136,11 +155,12 @@ class AccessTokenOnlyRegistrationEngine:
                         proxy=self.proxy_url,
                         verbose=False,
                         browser_mode=self.browser_mode,
+                        interrupt_checker=self.interrupt_checker,
                     )
                     chatgpt_client._log = self._log
 
                     self._log("步骤 1/2: 执行注册状态机...")
-
+                    self._checkpoint()
                     success, msg = chatgpt_client.register_complete_flow(
                         email_addr, pwd, first_name, last_name, birthdate, skymail_adapter
                     )
@@ -154,6 +174,7 @@ class AccessTokenOnlyRegistrationEngine:
                         return result
 
                     self._log("步骤 2/2: 复用注册会话，直接获取 ChatGPT Session / AccessToken...")
+                    self._checkpoint()
                     session_ok, session_result = chatgpt_client.reuse_session_and_get_tokens()
 
                     if session_ok:

--- a/platforms/chatgpt/chatgpt_client.py
+++ b/platforms/chatgpt/chatgpt_client.py
@@ -28,7 +28,6 @@ from .utils import (
     extract_flow_state,
     generate_datadog_trace,
     normalize_flow_url,
-    random_delay,
     seed_oai_device_cookie,
 )
 
@@ -76,7 +75,7 @@ class ChatGPTClient:
     BASE = "https://chatgpt.com"
     AUTH = "https://auth.openai.com"
 
-    def __init__(self, proxy=None, verbose=True, browser_mode="protocol"):
+    def __init__(self, proxy=None, verbose=True, browser_mode="protocol", interrupt_checker=None):
         """
         初始化 ChatGPT 客户端
 
@@ -88,6 +87,7 @@ class ChatGPTClient:
         self.proxy = proxy
         self.verbose = verbose
         self.browser_mode = browser_mode or "protocol"
+        self.interrupt_checker = interrupt_checker
         self.device_id = str(uuid.uuid4())
         self.accept_language = random.choice(
             [
@@ -132,7 +132,36 @@ class ChatGPTClient:
         seed_oai_device_cookie(self.session, self.device_id)
         self.last_registration_state = FlowState()
 
+    def _checkpoint(self):
+        checker = self.interrupt_checker
+        if callable(checker):
+            checker()
+
+    def _sleep_with_checkpoint(self, seconds: float):
+        remaining = max(float(seconds or 0), 0.0)
+        sleep_fn = time.sleep
+        while remaining > 0:
+            self._checkpoint()
+            chunk = min(0.25, remaining)
+            sleep_fn(chunk)
+            remaining -= chunk
+
+    def _session_get(self, url, **kwargs):
+        self._checkpoint()
+        session = self.session
+        response = session.get(url, **kwargs)
+        self._checkpoint()
+        return response
+
+    def _session_post(self, url, **kwargs):
+        self._checkpoint()
+        session = self.session
+        response = session.post(url, **kwargs)
+        self._checkpoint()
+        return response
+
     def _get_sentinel_token(self, flow: str, *, page_url: str | None = None):
+        self._checkpoint()
         prefer_browser = flow in {"username_password_create", "oauth_create_account"}
         if prefer_browser:
             # 服务器无 XServer，必须强制 headless
@@ -164,13 +193,14 @@ class ChatGPTClient:
 
     def _log(self, msg):
         """输出日志"""
+        self._checkpoint()
         if self.verbose:
             print(f"  {msg}")
 
     def _browser_pause(self, low=0.15, high=0.45):
         """在 headed 模式下加入轻微停顿，模拟有头浏览器节奏。"""
         if self.browser_mode == "headed":
-            random_delay(low, high)
+            self._sleep_with_checkpoint(random.uniform(low, high))
 
     def _headers(
         self,
@@ -313,7 +343,7 @@ class ChatGPTClient:
 
         try:
             self._browser_pause()
-            r = self.session.get(
+            r = self._session_get(
                 target_url,
                 headers=self._headers(
                     target_url,
@@ -362,7 +392,7 @@ class ChatGPTClient:
         """请求 ChatGPT Session 接口并返回原始会话数据。"""
         url = f"{self.BASE}/api/auth/session"
         self._browser_pause()
-        response = self.session.get(
+        response = self._session_get(
             url,
             headers=self._headers(
                 url,
@@ -461,7 +491,7 @@ class ChatGPTClient:
         url = f"{self.BASE}/"
         try:
             self._browser_pause()
-            r = self.session.get(
+            r = self._session_get(
                 url,
                 headers=self._headers(
                     url,
@@ -481,7 +511,7 @@ class ChatGPTClient:
         self._log("获取 CSRF token...")
         url = f"{self.BASE}/api/auth/csrf"
         try:
-            r = self.session.get(
+            r = self._session_get(
                 url,
                 headers=self._headers(
                     url,
@@ -529,7 +559,7 @@ class ChatGPTClient:
 
         try:
             self._browser_pause()
-            r = self.session.post(
+            r = self._session_post(
                 url,
                 params=params,
                 data=form_data,
@@ -569,12 +599,12 @@ class ChatGPTClient:
                     self._log(
                         f"访问 authorize URL... (尝试 {attempt + 1}/{max_retries})"
                     )
-                    time.sleep(1)  # 重试前等待
+                    self._sleep_with_checkpoint(1)  # 重试前等待
                 else:
                     self._log("访问 authorize URL...")
 
                 self._browser_pause()
-                r = self.session.get(
+                r = self._session_get(
                     url,
                     headers=self._headers(
                         url,
@@ -654,7 +684,7 @@ class ChatGPTClient:
 
         try:
             self._browser_pause()
-            r = self.session.post(url, json=payload, headers=headers, timeout=30)
+            r = self._session_post(url, json=payload, headers=headers, timeout=30)
 
             if r.status_code == 200:
                 data = r.json()
@@ -680,7 +710,7 @@ class ChatGPTClient:
 
         try:
             self._browser_pause()
-            r = self.session.get(
+            r = self._session_get(
                 url,
                 headers=self._headers(
                     url,
@@ -723,7 +753,7 @@ class ChatGPTClient:
 
         try:
             self._browser_pause()
-            r = self.session.post(url, json=payload, headers=headers, timeout=30)
+            r = self._session_post(url, json=payload, headers=headers, timeout=30)
 
             if r.status_code == 200:
                 try:
@@ -791,7 +821,7 @@ class ChatGPTClient:
 
         try:
             self._browser_pause()
-            r = self.session.post(url, json=payload, headers=headers, timeout=30)
+            r = self._session_post(url, json=payload, headers=headers, timeout=30)
 
             if r.status_code == 200:
                 try:

--- a/platforms/chatgpt/chatgpt_registration_mode_adapter.py
+++ b/platforms/chatgpt/chatgpt_registration_mode_adapter.py
@@ -61,6 +61,7 @@ class ChatGPTRegistrationContext:
     browser_mode: str
     max_retries: int
     extra_config: dict
+    interrupt_checker: Optional[Callable[[], None]] = None
 
 
 class BaseChatGPTRegistrationModeAdapter(ABC):
@@ -113,6 +114,7 @@ class RefreshTokenChatGPTRegistrationAdapter(BaseChatGPTRegistrationModeAdapter)
             proxy_url=context.proxy_url,
             callback_logger=context.callback_logger,
             browser_mode=context.browser_mode,
+            interrupt_checker=context.interrupt_checker,
         )
 
 
@@ -129,6 +131,7 @@ class AccessTokenOnlyChatGPTRegistrationAdapter(BaseChatGPTRegistrationModeAdapt
             callback_logger=context.callback_logger,
             max_retries=context.max_retries,
             extra_config=context.extra_config,
+            interrupt_checker=context.interrupt_checker,
         )
 
 

--- a/platforms/chatgpt/plugin.py
+++ b/platforms/chatgpt/plugin.py
@@ -173,6 +173,7 @@ class ChatGPTPlatform(BasePlatform):
             browser_mode=browser_mode,
             max_retries=max_retries,
             extra_config=extra_config,
+            interrupt_checker=self.build_interrupt_checker(),
         )
         result = adapter.run(context)
         if not result or not result.success:

--- a/platforms/chatgpt/refresh_token_registration_engine.py
+++ b/platforms/chatgpt/refresh_token_registration_engine.py
@@ -244,7 +244,8 @@ class RefreshTokenRegistrationEngine:
             self.email = email_value
             self._log(f"成功创建邮箱: {self.email}")
             return True
-
+        except TaskInterruption:
+            raise
         except Exception as e:
             self._log(f"创建邮箱失败: {e}", "error")
             return False
@@ -256,6 +257,8 @@ class RefreshTokenRegistrationEngine:
             self.oauth_start = self.oauth_manager.start_oauth()
             self._log(f"OAuth URL 已生成: {self.oauth_start.auth_url[:80]}...")
             return True
+        except TaskInterruption:
+            raise
         except Exception as e:
             self._log(f"生成 OAuth URL 失败: {e}", "error")
             return False
@@ -267,6 +270,8 @@ class RefreshTokenRegistrationEngine:
             if self._device_id:
                 seed_oai_device_cookie(self.session, self._device_id)
             return True
+        except TaskInterruption:
+            raise
         except Exception as e:
             self._log(f"初始化会话失败: {e}", "error")
             return False
@@ -300,6 +305,8 @@ class RefreshTokenRegistrationEngine:
                     f"获取 Device ID 失败: 建立 OAuth 会话返回 HTTP {response.status_code} (第 {attempt}/{max_attempts} 次)",
                     "warning" if attempt < max_attempts else "error"
                 )
+            except TaskInterruption:
+                raise
             except Exception as e:
                 self._log(
                     f"获取 Device ID 失败: {e} (第 {attempt}/{max_attempts} 次)",
@@ -391,6 +398,8 @@ class RefreshTokenRegistrationEngine:
                 return sen_token
             self._log(f"Sentinel 检查失败: 未获取到 token ({flow})", "warning")
             return None
+        except TaskInterruption:
+            raise
         except Exception as e:
             self._log(f"Sentinel 检查异常 ({flow}): {e}", "warning")
             return None
@@ -445,7 +454,8 @@ class RefreshTokenRegistrationEngine:
                     timeout=15,
                 )
                 self._log(f"{log_label}: 二次访问状态: {page_resp2.status_code}")
-                
+            except TaskInterruption:
+                raise
             except Exception as page_err:
                 self._log(f"{log_label}: 页面访问异常（继续尝试）: {page_err}")
 
@@ -507,11 +517,15 @@ class RefreshTokenRegistrationEngine:
                     response_data=response_data
                 )
 
+            except TaskInterruption:
+                raise
             except Exception as parse_error:
                 self._log(f"解析响应失败: {parse_error}", "warning")
                 # 无法解析，默认成功
                 return SignupFormResult(success=True)
 
+        except TaskInterruption:
+            raise
         except Exception as e:
             self._log(f"{log_label}失败: {e}", "error")
             return SignupFormResult(success=False, error_message=str(e))
@@ -586,6 +600,8 @@ class RefreshTokenRegistrationEngine:
                 response_data=response_data,
             )
 
+        except TaskInterruption:
+            raise
         except Exception as e:
             self._log(f"提交登录密码失败: {e}", "error")
             return SignupFormResult(success=False, error_message=str(e))

--- a/platforms/chatgpt/refresh_token_registration_engine.py
+++ b/platforms/chatgpt/refresh_token_registration_engine.py
@@ -104,6 +104,7 @@ class RefreshTokenRegistrationEngine:
         callback_logger: Optional[Callable[[str], None]] = None,
         task_uuid: Optional[str] = None,
         browser_mode: str = "headless",
+        interrupt_checker: Optional[Callable[[], None]] = None,
     ):
         """
         初始化注册引擎
@@ -119,6 +120,7 @@ class RefreshTokenRegistrationEngine:
         self.callback_logger = callback_logger or (lambda msg: logger.info(msg))
         self.task_uuid = task_uuid
         self.browser_mode = str(browser_mode or "headless").strip().lower()
+        self.interrupt_checker = interrupt_checker
 
         # 创建 HTTP 客户端
         self.http_client = OpenAIHTTPClient(proxy_url=proxy_url)
@@ -150,8 +152,37 @@ class RefreshTokenRegistrationEngine:
         self._post_otp_continue_url: str = ""
         self._post_otp_page_type: str = ""
 
+    def _checkpoint(self) -> None:
+        checker = self.interrupt_checker
+        if callable(checker):
+            checker()
+
+    def _sleep_with_checkpoint(self, seconds: float) -> None:
+        remaining = max(float(seconds or 0), 0.0)
+        sleep_fn = time.sleep
+        while remaining > 0:
+            self._checkpoint()
+            chunk = min(0.25, remaining)
+            sleep_fn(chunk)
+            remaining -= chunk
+
+    def _session_get(self, url: str, **kwargs):
+        self._checkpoint()
+        session = self.session
+        response = session.get(url, **kwargs)
+        self._checkpoint()
+        return response
+
+    def _session_post(self, url: str, **kwargs):
+        self._checkpoint()
+        session = self.session
+        response = session.post(url, **kwargs)
+        self._checkpoint()
+        return response
+
     def _log(self, message: str, level: str = "info"):
         """记录日志"""
+        self._checkpoint()
         timestamp = datetime.now().strftime("%H:%M:%S")
         log_message = f"[{timestamp}] {message}"
 
@@ -256,7 +287,7 @@ class RefreshTokenRegistrationEngine:
 
                 seed_oai_device_cookie(self.session, self._device_id)
 
-                response = self.session.get(
+                response = self._session_get(
                     self.oauth_start.auth_url,
                     timeout=20
                 )
@@ -276,7 +307,7 @@ class RefreshTokenRegistrationEngine:
                 )
 
             if attempt < max_attempts:
-                time.sleep(attempt)
+                self._sleep_with_checkpoint(attempt)
                 self.http_client.close()
                 self.session = self.http_client.session
 
@@ -388,7 +419,7 @@ class RefreshTokenRegistrationEngine:
                 nav_headers = self._build_navigation_headers(referer=page_url)
                 
                 # 第一次访问：获取 cf_clearance cookie
-                page_resp = self.session.get(
+                page_resp = self._session_get(
                     page_url,
                     headers=nav_headers,
                     allow_redirects=True,
@@ -404,10 +435,10 @@ class RefreshTokenRegistrationEngine:
                     self._log(f"{log_label}: 未获取到 cf_clearance，可能需要等待")
                 
                 # 等待 Cloudflare JS challenge 完成
-                time.sleep(random.uniform(2.0, 4.0))
+                self._sleep_with_checkpoint(random.uniform(2.0, 4.0))
                 
                 # 第二次访问：确保 challenge 完全完成
-                page_resp2 = self.session.get(
+                page_resp2 = self._session_get(
                     page_url,
                     headers=nav_headers,
                     allow_redirects=True,
@@ -437,9 +468,9 @@ class RefreshTokenRegistrationEngine:
                 headers["openai-sentinel-token"] = sen_token
 
             # 提交请求前添加自然延迟
-            time.sleep(random.uniform(0.8, 2.0))
+            self._sleep_with_checkpoint(random.uniform(0.8, 2.0))
 
-            response = self.session.post(
+            response = self._session_post(
                 OPENAI_API_ENDPOINTS["signup"],
                 headers=headers,
                 data=request_body,
@@ -525,7 +556,7 @@ class RefreshTokenRegistrationEngine:
             if sen_token:
                 headers["openai-sentinel-token"] = sen_token
 
-            response = self.session.post(
+            response = self._session_post(
                 OPENAI_API_ENDPOINTS["password_verify"],
                 headers=headers,
                 data=json.dumps({"password": self.password}),
@@ -615,7 +646,7 @@ class RefreshTokenRegistrationEngine:
             self._log("尝试 1：直接访问 consent 页面...")
             try:
                 consent_url = "https://auth.openai.com/sign-in-with-chatgpt/codex/consent"
-                consent_resp = self.session.get(
+                consent_resp = self._session_get(
                     consent_url,
                     headers=self._build_navigation_headers(referer=consent_url),
                     allow_redirects=True,
@@ -631,7 +662,7 @@ class RefreshTokenRegistrationEngine:
                     self._log(f"consent 最终 URL: {final_url}")
                     
                     # 等待一下让 cookie 完全设置
-                    time.sleep(random.uniform(1.0, 2.0))
+                    self._sleep_with_checkpoint(random.uniform(1.0, 2.0))
                     
                     # 检查是否有 oai-client-auth-session cookie
                     auth_cookie = self.session.cookies.get("oai-client-auth-session")
@@ -648,7 +679,7 @@ class RefreshTokenRegistrationEngine:
             if getattr(self, "_post_otp_page_type", "") == "add_phone":
                 self._log("尝试 2：访问 about-you 页面建立 Cookie...")
                 try:
-                    about_resp = self.session.get(
+                    about_resp = self._session_get(
                         "https://auth.openai.com/about-you",
                         headers=self._build_navigation_headers(
                             referer="https://auth.openai.com/email-verification"
@@ -688,7 +719,7 @@ class RefreshTokenRegistrationEngine:
             try:
                 about_you_url = "https://auth.openai.com/about-you"
                 nav_headers = self._build_navigation_headers(referer=about_you_url)
-                page_resp = self.session.get(
+                page_resp = self._session_get(
                     about_you_url,
                     headers=nav_headers,
                     allow_redirects=True,
@@ -696,7 +727,7 @@ class RefreshTokenRegistrationEngine:
                 )
                 self._log(f"访问 about-you 页面状态: {page_resp.status_code}")
                 # 等待页面完成 Cookie 设置
-                time.sleep(random.uniform(2.0, 4.0))
+                self._sleep_with_checkpoint(random.uniform(2.0, 4.0))
                 
                 # 检查重定向后的 URL，看是否已经跳转到 consent 或其他页面
                 final_url = str(page_resp.url or "")
@@ -806,14 +837,14 @@ class RefreshTokenRegistrationEngine:
             try:
                 page_url = "https://auth.openai.com/create-account/password"
                 nav_headers = self._build_navigation_headers(referer=page_url)
-                page_resp = self.session.get(
+                page_resp = self._session_get(
                     page_url,
                     headers=nav_headers,
                     allow_redirects=True,
                     timeout=15,
                 )
                 self._log(f"提交密码前：页面访问状态: {page_resp.status_code}")
-                time.sleep(random.uniform(1.5, 3.0))
+                self._sleep_with_checkpoint(random.uniform(1.5, 3.0))
             except Exception as page_err:
                 self._log(f"提交密码前：页面访问异常（继续尝试）: {page_err}")
 
@@ -836,9 +867,9 @@ class RefreshTokenRegistrationEngine:
                 headers["openai-sentinel-token"] = sen_token
 
             # 提交前添加自然延迟
-            time.sleep(random.uniform(1.0, 2.5))
+            self._sleep_with_checkpoint(random.uniform(1.0, 2.5))
 
-            response = self.session.post(
+            response = self._session_post(
                 OPENAI_API_ENDPOINTS["register"],
                 headers=headers,
                 data=register_body,
@@ -903,9 +934,9 @@ class RefreshTokenRegistrationEngine:
             for attempt in range(1, max_retries + 2):
                 if attempt > 1:
                     self._log(f"验证码发送重试 {attempt - 1}/{max_retries}...", "warning")
-                    time.sleep(random.uniform(2.0, 4.0))
+                    self._sleep_with_checkpoint(random.uniform(2.0, 4.0))
 
-                response = self.session.get(
+                response = self._session_get(
                     OPENAI_API_ENDPOINTS["send_otp"],
                     headers=self._build_navigation_headers(
                         referer="https://auth.openai.com/create-account/password"
@@ -1075,7 +1106,7 @@ class RefreshTokenRegistrationEngine:
                 try:
                     email_verification_url = "https://auth.openai.com/email-verification"
                     nav_headers = self._build_navigation_headers(referer=email_verification_url)
-                    page_resp = self.session.get(
+                    page_resp = self._session_get(
                         email_verification_url,
                         headers=nav_headers,
                         allow_redirects=True,
@@ -1083,19 +1114,19 @@ class RefreshTokenRegistrationEngine:
                     )
                     self._log(f"验证前：邮箱验证页面状态: {page_resp.status_code}")
                     # 模拟用户阅读验证码的时间（3-8秒）
-                    time.sleep(random.uniform(3.0, 8.0))
+                    self._sleep_with_checkpoint(random.uniform(3.0, 8.0))
                 except Exception as page_err:
                     self._log(f"验证前：页面访问异常（继续）: {page_err}")
 
                 # 模拟用户输入验证码的节奏（逐位输入，每位间隔0.5-1.5秒）
                 self._log(f"模拟输入验证码: {code}...")
                 for i, digit in enumerate(str(code)):
-                    time.sleep(random.uniform(0.5, 1.5))
+                    self._sleep_with_checkpoint(random.uniform(0.5, 1.5))
                     if i < len(str(code)) - 1:
                         self._log(f"  输入第 {i+1} 位: {digit}")
 
                 # 输入完成后停顿1-3秒再提交
-                time.sleep(random.uniform(1.0, 3.0))
+                self._sleep_with_checkpoint(random.uniform(1.0, 3.0))
 
                 code_body = f'{{"code":"{code}"}}'
                 headers = self._build_json_headers(
@@ -1110,7 +1141,7 @@ class RefreshTokenRegistrationEngine:
                 if sen_token:
                     headers["openai-sentinel-token"] = sen_token
 
-                response = self.session.post(
+                response = self._session_post(
                     OPENAI_API_ENDPOINTS["validate_otp"],
                     headers=headers,
                     data=code_body,
@@ -1144,7 +1175,7 @@ class RefreshTokenRegistrationEngine:
                     
                     if attempt <= max_retries:
                         self._log(f"将在 {attempt}/{max_retries} 次重试后重新获取验证码", "warning")
-                        time.sleep(random.uniform(2.0, 4.0))
+                        self._sleep_with_checkpoint(random.uniform(2.0, 4.0))
                         continue
                     else:
                         self._log("验证码验证失败，已达到最大重试次数", "error")
@@ -1175,7 +1206,7 @@ class RefreshTokenRegistrationEngine:
             if sen_token:
                 headers["openai-sentinel-token"] = sen_token
 
-            response = self.session.post(
+            response = self._session_post(
                 OPENAI_API_ENDPOINTS["create_account"],
                 headers=headers,
                 data=create_account_body,
@@ -1204,7 +1235,7 @@ class RefreshTokenRegistrationEngine:
             if retry_token:
                 headers["openai-sentinel-token"] = retry_token
 
-            retry_resp = self.session.post(
+            retry_resp = self._session_post(
                 OPENAI_API_ENDPOINTS["create_account"],
                 headers=headers,
                 data=create_account_body,
@@ -1280,7 +1311,7 @@ class RefreshTokenRegistrationEngine:
             self._log(f"OAuth 跟随重定向 {hop + 1}/{max_depth}: {current_url[:120]}...")
 
             try:
-                response = self.session.get(
+                response = self._session_get(
                     current_url,
                     headers=self._build_navigation_headers(referer=referer),
                     allow_redirects=False,
@@ -1322,7 +1353,7 @@ class RefreshTokenRegistrationEngine:
             headers["openai-sentinel-token"] = sen_token
 
         try:
-            response = self.session.post(
+            response = self._session_post(
                 OPENAI_API_ENDPOINTS["create_account"],
                 headers=headers,
                 data=json.dumps(user_info),
@@ -1358,7 +1389,7 @@ class RefreshTokenRegistrationEngine:
         if continue_url and "about-you" in continue_url:
             self._log("OTP 后进入 about-you，按参考 RT 逻辑补齐 consent 跳转...")
             try:
-                response = self.session.get(
+                response = self._session_get(
                     "https://auth.openai.com/about-you",
                     headers=self._build_navigation_headers(
                         referer="https://auth.openai.com/email-verification"
@@ -1394,11 +1425,18 @@ class RefreshTokenRegistrationEngine:
         """从 oai-client-auth-session cookie 中解析 workspace_id。"""
         try:
             # 先列出所有可用的 cookies，帮助诊断
-            all_cookies = {name: value[:50] + "..." if len(value) > 50 else value 
-                          for name, value in self.session.cookies.get_dict().items()}
-            self._log(f"当前会话 cookies: {list(all_cookies.keys())}")
+            cookies = getattr(self.session, "cookies", None)
+            get_dict = getattr(cookies, "get_dict", None)
+            if callable(get_dict):
+                cookie_map = get_dict()
+                if isinstance(cookie_map, dict):
+                    all_cookies = {
+                        name: value[:50] + "..." if len(value) > 50 else value
+                        for name, value in cookie_map.items()
+                    }
+                    self._log(f"当前会话 cookies: {list(all_cookies.keys())}")
             
-            auth_cookie = self.session.cookies.get("oai-client-auth-session")
+            auth_cookie = cookies.get("oai-client-auth-session") if cookies is not None else None
             if not auth_cookie:
                 self._log("未能解码 oai-client-auth-session Cookie", "error")
                 self._log("提示: 这可能意味着 OpenAI 尚未完成会话初始化", "warning")
@@ -1432,7 +1470,7 @@ class RefreshTokenRegistrationEngine:
         """通过 API 获取 workspace_id（备用方案）。"""
         try:
             self._log("通过 API 获取 workspace 列表...")
-            response = self.session.get(
+            response = self._session_get(
                 "https://auth.openai.com/api/accounts/workspace/",
                 headers=self._build_navigation_headers(
                     referer="https://auth.openai.com/sign-in-with-chatgpt/codex/consent"
@@ -1471,7 +1509,7 @@ class RefreshTokenRegistrationEngine:
     def _select_workspace(self, workspace_id: str) -> Optional[str]:
         """兼容旧逻辑：仅提交 workspace 并返回 continue_url。"""
         try:
-            response = self.session.post(
+            response = self._session_post(
                 OPENAI_API_ENDPOINTS["select_workspace"],
                 headers=self._build_json_headers(
                     referer="https://auth.openai.com/sign-in-with-chatgpt/codex/consent",
@@ -1518,7 +1556,7 @@ class RefreshTokenRegistrationEngine:
         self._log(f"consent URL: {consent_url}")
 
         try:
-            response = self.session.get(
+            response = self._session_get(
                 consent_url,
                 headers=self._build_navigation_headers(
                     referer="https://auth.openai.com/email-verification"
@@ -1543,7 +1581,7 @@ class RefreshTokenRegistrationEngine:
         workspace_id = self._get_workspace_id() or ""
         if workspace_id:
             try:
-                ws_response = self.session.post(
+                ws_response = self._session_post(
                     OPENAI_API_ENDPOINTS["select_workspace"],
                     headers=self._build_json_headers(
                         referer=consent_url,
@@ -1595,7 +1633,7 @@ class RefreshTokenRegistrationEngine:
                                 org_payload["project_id"] = project_id
 
                             org_referer = ws_continue_url or consent_url
-                            org_response = self.session.post(
+                            org_response = self._session_post(
                                 OPENAI_API_ENDPOINTS["select_organization"],
                                 headers=self._build_json_headers(
                                     referer=org_referer,
@@ -1652,7 +1690,7 @@ class RefreshTokenRegistrationEngine:
                 self._log(f"处理 workspace/select 响应异常: {e}", "warning")
 
         try:
-            response = self.session.get(
+            response = self._session_get(
                 consent_url,
                 headers=self._build_navigation_headers(
                     referer="https://auth.openai.com/email-verification"
@@ -1698,7 +1736,7 @@ class RefreshTokenRegistrationEngine:
                     if attempt < max_retries:
                         self._log(f"OAuth 回调处理失败 (尝试 {attempt}/{max_retries}): {retry_error}", "warning")
                         import time
-                        time.sleep(2)  # 等待 2 秒后重试
+                        self._sleep_with_checkpoint(2)  # 等待 2 秒后重试
                     else:
                         raise
 

--- a/tests/test_chatgpt_access_token_engine.py
+++ b/tests/test_chatgpt_access_token_engine.py
@@ -1,0 +1,31 @@
+import unittest
+
+from core.task_runtime import StopTaskRequested
+from platforms.chatgpt.access_token_only_registration_engine import (
+    AccessTokenOnlyRegistrationEngine,
+)
+
+
+class _DummyEmailService:
+    def create_email(self):
+        return {"email": "user@example.com", "service_id": "svc-1"}
+
+    def get_verification_code(self, **kwargs):
+        return "123456"
+
+
+class AccessTokenOnlyRegistrationEngineTests(unittest.TestCase):
+    def test_run_propagates_stop_request_via_interrupt_checker(self):
+        engine = AccessTokenOnlyRegistrationEngine(
+            email_service=_DummyEmailService(),
+            proxy_url="http://127.0.0.1:7890",
+            callback_logger=lambda msg: None,
+            interrupt_checker=lambda: (_ for _ in ()).throw(StopTaskRequested()),
+        )
+
+        with self.assertRaises(StopTaskRequested):
+            engine.run()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_chatgpt_register.py
+++ b/tests/test_chatgpt_register.py
@@ -3,6 +3,7 @@ import json
 import unittest
 from unittest import mock
 
+from core.task_runtime import StopTaskRequested
 from platforms.chatgpt.refresh_token_registration_engine import (
     RefreshTokenRegistrationEngine,
     SignupFormResult,
@@ -234,6 +235,17 @@ class RegistrationEngineFlowTests(unittest.TestCase):
         create_account.assert_not_called()
         restart_login.assert_not_called()
         complete_exchange.assert_called_once()
+
+    def test_run_propagates_stop_request_via_interrupt_checker(self):
+        engine = RefreshTokenRegistrationEngine(
+            email_service=DummyEmailService(),
+            proxy_url="http://127.0.0.1:7890",
+            callback_logger=lambda msg: None,
+            interrupt_checker=lambda: (_ for _ in ()).throw(StopTaskRequested()),
+        )
+
+        with self.assertRaises(StopTaskRequested):
+            engine.run()
 
     @mock.patch(
         "platforms.chatgpt.refresh_token_registration_engine.build_sentinel_token",

--- a/tests/test_chatgpt_register.py
+++ b/tests/test_chatgpt_register.py
@@ -3,7 +3,7 @@ import json
 import unittest
 from unittest import mock
 
-from core.task_runtime import StopTaskRequested
+from core.task_runtime import SkipCurrentAttemptRequested, StopTaskRequested
 from platforms.chatgpt.refresh_token_registration_engine import (
     RefreshTokenRegistrationEngine,
     SignupFormResult,
@@ -138,6 +138,26 @@ class RegistrationEngineFlowTests(unittest.TestCase):
                 (second_session, "device-fixed"),
             ],
         )
+
+    def test_get_device_id_propagates_skip_without_retry(self):
+        engine = RefreshTokenRegistrationEngine(
+            email_service=DummyEmailService(),
+            proxy_url="http://127.0.0.1:7890",
+            callback_logger=lambda msg: None,
+            interrupt_checker=lambda: (_ for _ in ()).throw(
+                SkipCurrentAttemptRequested()
+            ),
+        )
+        engine.oauth_start = mock.Mock(
+            auth_url="https://auth.openai.com/oauth/authorize"
+        )
+        engine.session = mock.Mock()
+        engine.session.get = mock.Mock()
+
+        with self.assertRaises(SkipCurrentAttemptRequested):
+            engine._get_device_id()
+
+        engine.session.get.assert_not_called()
 
     def test_run_restarts_login_after_new_registration(self):
         engine = self._make_engine()

--- a/tests/test_chatgpt_registration_mode_adapter.py
+++ b/tests/test_chatgpt_registration_mode_adapter.py
@@ -57,6 +57,7 @@ class ChatGPTRegistrationModeAdapterTests(unittest.TestCase):
 
     def test_access_token_only_adapter_passes_runtime_context_to_engine(self):
         created = {}
+        interrupt_checker = lambda: None
 
         class FakeEngine:
             def __init__(self, **kwargs):
@@ -81,6 +82,7 @@ class ChatGPTRegistrationModeAdapterTests(unittest.TestCase):
             browser_mode="headed",
             max_retries=5,
             extra_config={"register_max_retries": 5},
+            interrupt_checker=interrupt_checker,
         )
 
         with mock.patch(
@@ -93,6 +95,7 @@ class ChatGPTRegistrationModeAdapterTests(unittest.TestCase):
         self.assertEqual(created["password"], "pw-demo")
         self.assertEqual(created["kwargs"]["browser_mode"], "headed")
         self.assertEqual(created["kwargs"]["max_retries"], 5)
+        self.assertIs(created["kwargs"]["interrupt_checker"], interrupt_checker)
 
 
 if __name__ == "__main__":

--- a/tests/test_task_api_controls.py
+++ b/tests/test_task_api_controls.py
@@ -1,0 +1,71 @@
+import unittest
+
+from fastapi.testclient import TestClient
+
+from api.tasks import _create_task_record, _task_store, RegisterTaskRequest
+from main import app
+
+
+class TaskApiControlTests(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+        self.req = RegisterTaskRequest(platform="chatgpt", count=1, concurrency=1)
+
+    def test_skip_current_endpoint_returns_control_snapshot(self):
+        task_id = "task-api-skip"
+        _create_task_record(task_id, self.req, "manual", {"scope": "unit"})
+
+        response = self.client.post(f"/api/tasks/{task_id}/skip-current")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["task_id"], task_id)
+        self.assertIn("control", payload)
+        self.assertEqual(payload["control"]["pending_skip_requests"], 1)
+
+    def test_stop_endpoint_marks_control_as_requested(self):
+        task_id = "task-api-stop"
+        _create_task_record(task_id, self.req, "manual", {"scope": "unit"})
+
+        response = self.client.post(f"/api/tasks/{task_id}/stop")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["control"]["stop_requested"])
+
+        snapshot = self.client.get(f"/api/tasks/{task_id}").json()
+        self.assertTrue(snapshot["control"]["stop_requested"])
+
+    def test_control_endpoints_return_404_for_unknown_task(self):
+        self.assertEqual(
+            self.client.post("/api/tasks/task-missing/skip-current").status_code,
+            404,
+        )
+        self.assertEqual(
+            self.client.post("/api/tasks/task-missing/stop").status_code,
+            404,
+        )
+
+    def test_stream_logs_finishes_when_task_is_stopped(self):
+        task_id = "task-api-stream-stop"
+        _create_task_record(task_id, self.req, "manual", {"scope": "unit"})
+        _task_store.append_log(task_id, "[12:00:00] 等待中")
+        _task_store.finish(
+            task_id,
+            status="stopped",
+            success=0,
+            skipped=0,
+            errors=[],
+        )
+
+        with self.client.stream("GET", f"/api/tasks/{task_id}/logs/stream") as response:
+            self.assertEqual(response.status_code, 200)
+            body = "".join(response.iter_text())
+
+        self.assertIn('"line": "[12:00:00] \\u7b49\\u5f85\\u4e2d"', body)
+        self.assertIn('"done": true', body)
+        self.assertIn('"status": "stopped"', body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_task_runtime.py
+++ b/tests/test_task_runtime.py
@@ -1,11 +1,23 @@
 import unittest
 
+from core.base_platform import BasePlatform, RegisterConfig
 from core.task_runtime import (
     RegisterTaskControl,
     RegisterTaskStore,
     SkipCurrentAttemptRequested,
     StopTaskRequested,
 )
+
+
+class _DummyPlatform(BasePlatform):
+    name = "dummy"
+    display_name = "Dummy"
+
+    def register(self, email: str, password: str = None):
+        return None
+
+    def check_valid(self, account) -> bool:
+        return True
 
 
 class RegisterTaskControlTests(unittest.TestCase):
@@ -47,6 +59,20 @@ class RegisterTaskControlTests(unittest.TestCase):
         attempt_c = control.start_attempt()
         control.checkpoint(attempt_id=attempt_c)
         control.finish_attempt(attempt_c)
+
+    def test_platform_interrupt_checker_consumes_targeted_skip_for_active_attempt(self):
+        control = RegisterTaskControl()
+        platform = _DummyPlatform(RegisterConfig())
+        platform.bind_task_control(control)
+        platform._task_attempt_token = control.start_attempt()
+        checker = platform.build_interrupt_checker()
+
+        control.request_skip_current()
+
+        with self.assertRaises(SkipCurrentAttemptRequested):
+            checker()
+
+        control.finish_attempt(platform._task_attempt_token)
 
 
 class RegisterTaskStoreTests(unittest.TestCase):


### PR DESCRIPTION
## 变更说明

本次 MR 修复 ChatGPT 注册任务中“停止任务”和“跳过当前账号”控制失效的问题。

此前前端按钮虽然可以发起请求，但后端和 ChatGPT 注册流程内部对任务控制信号的消费不完整，导致：
- `stop` 接口可能返回成功，但注册流程不会及时中断
- `skip-current` 在 ChatGPT 注册链路中无法准确命中当前 attempt
- 手动跳过后，部分授权步骤会把跳过当成普通失败继续重试

## 修复内容

### 1. 统一任务控制能力
- 补齐任务控制接口，支持：
  - `POST /api/tasks/{task_id}/stop`
  - `POST /api/tasks/{task_id}/skip-current`
- 将注册任务执行统一接入 `RegisterTaskStore / RegisterTaskControl`
- SSE 日志流支持在 `stopped` 状态下正确结束

### 2. 修复 ChatGPT 注册流程中的 stop/skip 信号传递
- 将任务中断检查器从任务运行时传递到：
  - ChatGPT platform
  - registration mode adapter
  - refresh token registration engine
  - access token only registration engine
  - ChatGPT client
- 在 ChatGPT 注册关键流程中加入 checkpoint，包括：
  - 初始化会话
  - OAuth 启动
  - 获取 Device ID
  - Sentinel 校验
  - 提交注册邮箱
  - Cloudflare 等待
  - HTTP 请求前后
  - 各类 sleep / retry 等待点

### 3. 修复 skip-current 无法命中当前账号的问题
- 为平台实例补充当前 attempt token
- `build_interrupt_checker()` 和平台级 checkpoint 在消费信号时带上当前 attempt id
- 确保 `skip-current` 只作用于当前活跃账号，而不是退化成无效请求

### 4. 修复“手动跳过后仍继续失败重试”的问题
- 在 ChatGPT refresh token 注册链路中，`SkipCurrentAttemptRequested` 不再被普通异常分支吞掉
- 对于以下关键步骤，手动跳过会直接中断当前账号，而不是继续重试：
  - 创建邮箱
  - 初始化会话
  - 启动 OAuth
  - 获取 Device ID
  - Sentinel 校验
  - 提交注册表单
  - 提交登录密码

## 测试

已通过以下测试：
- `tests.test_task_runtime`
- `tests.test_register_task_controls`
- `tests.test_mailbox_task_control`
- `tests.test_task_api_controls`
- `tests.test_chatgpt_register`
- `tests.test_chatgpt_registration_mode_adapter`
- `tests.test_chatgpt_access_token_engine`

本地验证命令：
```bash
python -m unittest \
  tests.test_task_runtime \
  tests.test_register_task_controls \
  tests.test_mailbox_task_control \
  tests.test_task_api_controls \
  tests.test_chatgpt_register \
  tests.test_chatgpt_registration_mode_adapter \
  tests.test_chatgpt_access_token_engine
